### PR TITLE
SPI overhaul

### DIFF
--- a/spring-cloud-deployer-core/pom.xml
+++ b/spring-cloud-deployer-core/pom.xml
@@ -22,6 +22,11 @@
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-core</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-deployer-spi</artifactId>
+			<version>${project.version}</version>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/spring-cloud-deployer-core/src/main/java/org/springframework/cloud/deployer/resolver/ArtifactResolver.java
+++ b/spring-cloud-deployer-core/src/main/java/org/springframework/cloud/deployer/resolver/ArtifactResolver.java
@@ -16,14 +16,25 @@
 
 package org.springframework.cloud.deployer.resolver;
 
-import org.springframework.cloud.deployer.core.ArtifactMetadata;
+import org.springframework.cloud.deployer.spi.ArtifactMetadata;
 import org.springframework.core.io.Resource;
 
 /**
+ * A strategy interface resolving a {@link Resource} based
+ * on an {@link ArtifactMetadata}.
+ *
  * @author Mark Fisher
+ * @author Janne Valkealahti
+ *
+ * @param <A> the type of artifact metadata
  */
 public interface ArtifactResolver<A extends ArtifactMetadata> {
 
+	/**
+	 * Resolve a resource based on a given metadata.
+	 *
+	 * @param metadata the artifact metadata
+	 * @return the resource
+	 */
 	Resource resolve(A metadata);
-
 }

--- a/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployer.java
+++ b/spring-cloud-deployer-local/src/main/java/org/springframework/cloud/deployer/spi/local/LocalAppDeployer.java
@@ -23,22 +23,31 @@ import java.util.Map;
 import org.springframework.boot.loader.JarLauncher;
 import org.springframework.boot.loader.archive.Archive;
 import org.springframework.boot.loader.archive.JarFileArchive;
-import org.springframework.cloud.deployer.core.AppDeploymentId;
-import org.springframework.cloud.deployer.core.AppDeploymentRequest;
 import org.springframework.cloud.deployer.resolver.ArtifactResolver;
 import org.springframework.cloud.deployer.resolver.maven.MavenCoordinates;
 import org.springframework.cloud.deployer.spi.AppDeployer;
-import org.springframework.cloud.deployer.status.AppStatus;
+import org.springframework.cloud.deployer.spi.AppDeploymentId;
+import org.springframework.cloud.deployer.spi.AppDeploymentRequest;
+import org.springframework.cloud.deployer.spi.status.AppStatus;
 import org.springframework.core.io.Resource;
 import org.springframework.util.Assert;
 
 /**
+ * Implementation of a {@link AppDeployer} deploying app locally
+ * using a {@link MavenCoordinates}.
+ *
  * @author Mark Fisher
+ * @author Janne Valkealahti
  */
 public class LocalAppDeployer implements AppDeployer<MavenCoordinates> {
 
 	private final ArtifactResolver<MavenCoordinates> resolver;
 
+	/**
+	 * Instantiates a new local app deployer.
+	 *
+	 * @param resolver the artifact resolver
+	 */
 	public LocalAppDeployer(ArtifactResolver<MavenCoordinates> resolver) {
 		Assert.notNull(resolver, "ArtifactResolver must not be null");
 		this.resolver = resolver;
@@ -55,7 +64,7 @@ public class LocalAppDeployer implements AppDeployer<MavenCoordinates> {
 		catch (IOException e) {
 			throw new RuntimeException(e);
 		}
-		return AppDeploymentId.fromAppDefinition(request.getDefinition());
+		return new AppDeploymentId(request.getDefinition().getGroup(), request.getDefinition().getName());
 	}
 
 	@Override
@@ -66,11 +75,6 @@ public class LocalAppDeployer implements AppDeployer<MavenCoordinates> {
 	@Override
 	public AppStatus status(AppDeploymentId id) {
 		return AppStatus.of(id).build();
-	}
-
-	@Override
-	public Map<AppDeploymentId, AppStatus> status() {
-		throw new UnsupportedOperationException("not yet implemented");
 	}
 
 	private String[] generateArgs(AppDeploymentRequest<MavenCoordinates> request) {

--- a/spring-cloud-deployer-resolver-maven/src/main/java/org/springframework/cloud/deployer/resolver/maven/MavenCoordinates.java
+++ b/spring-cloud-deployer-resolver-maven/src/main/java/org/springframework/cloud/deployer/resolver/maven/MavenCoordinates.java
@@ -19,11 +19,13 @@ package org.springframework.cloud.deployer.resolver.maven;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.springframework.cloud.deployer.core.ArtifactMetadata;
+import org.springframework.cloud.deployer.spi.ArtifactMetadata;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
 /**
+ * {@link ArtifactMetadata} strategy using maven coordinates.
+ * <p>
  * The {@code MavenCoordinates} class contains <a href="https://maven.apache.org/pom.html#Maven_Coordinates">
  * Maven coordinates</a> for a jar file containing an app/library, or a Bill of Materials pom.
  * <p>
@@ -89,6 +91,7 @@ public class MavenCoordinates implements ArtifactMetadata {
 
 	/**
 	 * Construct a {@code MavenCoordinates} object.
+	 *
 	 * @param groupId group ID for artifact
 	 * @param artifactId artifact ID
 	 * @param extension the file extension
@@ -245,5 +248,4 @@ public class MavenCoordinates implements ArtifactMetadata {
 			return new MavenCoordinates(groupId, artifactId, extension, classifier, version);
 		}
 	}
-
 }

--- a/spring-cloud-deployer-sample-stream/src/main/java/sample/StreamAppLauncher.java
+++ b/spring-cloud-deployer-sample-stream/src/main/java/sample/StreamAppLauncher.java
@@ -20,13 +20,13 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.springframework.cloud.deployer.core.AppDefinition;
-import org.springframework.cloud.deployer.core.AppDeploymentId;
-import org.springframework.cloud.deployer.core.AppDeploymentRequest;
 import org.springframework.cloud.deployer.resolver.maven.MavenArtifactResolver;
 import org.springframework.cloud.deployer.resolver.maven.MavenCoordinates;
+import org.springframework.cloud.deployer.spi.AppDefinition;
+import org.springframework.cloud.deployer.spi.AppDeploymentId;
+import org.springframework.cloud.deployer.spi.AppDeploymentRequest;
 import org.springframework.cloud.deployer.spi.local.LocalAppDeployer;
-import org.springframework.cloud.deployer.status.AppStatus;
+import org.springframework.cloud.deployer.spi.status.AppStatus;
 
 /**
  * @author Mark Fisher

--- a/spring-cloud-deployer-spi/pom.xml
+++ b/spring-cloud-deployer-spi/pom.xml
@@ -19,9 +19,8 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-deployer-core</artifactId>
-			<version>${project.version}</version>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-core</artifactId>
 		</dependency>
 	</dependencies>
 

--- a/spring-cloud-deployer-spi/src/main/java/org/springframework/cloud/deployer/spi/AppDefinition.java
+++ b/spring-cloud-deployer-spi/src/main/java/org/springframework/cloud/deployer/spi/AppDefinition.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.deployer.core;
+package org.springframework.cloud.deployer.spi;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -24,11 +24,14 @@ import org.springframework.core.style.ToStringCreator;
 import org.springframework.util.Assert;
 
 /**
- * Representation of an app, including configuration properties.
- * This does not include information required at deployment
- * time (such as the number of app instances).
+ * {@code AppDefinition} contains information about an app itself.
+ * Deployer should not modify parameters in this class as those are
+ * meant for an actual app as is. Deployer's only responsibility is to pass
+ * those parameters into a runtime environment in a way that parameters are
+ * available in a running application.
  *
  * @author Mark Fisher
+ * @author Janne Valkealahti
  */
 public class AppDefinition {
 
@@ -56,7 +59,6 @@ public class AppDefinition {
 	 */
 	public AppDefinition(String name, String group, Map<String, String> properties) {
 		Assert.notNull(name, "name must not be null");
-		Assert.notNull(group, "group must not be null");
 		this.name = name;
 		this.group = group;
 		this.properties = properties == null
@@ -67,7 +69,7 @@ public class AppDefinition {
 	/**
 	 * Return the name of this app.
 	 *
-	 * @return app name
+	 * @return the app name
 	 */
 	public String getName() {
 		return name;
@@ -76,16 +78,16 @@ public class AppDefinition {
 	/**
 	 * Return name of group this app instance belongs to.
 	 *
-	 * @return group name
+	 * @return the group name
 	 */
 	public String getGroup() {
 		return group;
 	}
 
 	/**
-	 * Return properties for this app.
+	 * Gets the app definition parameters. These parameters are passed into a running app.
 	 *
-	 * @return read-only map of app properties
+	 * @return the unmodifiable map of app properties
 	 */
 	public Map<String, String> getProperties() {
 		return properties;

--- a/spring-cloud-deployer-spi/src/main/java/org/springframework/cloud/deployer/spi/AppDeployer.java
+++ b/spring-cloud-deployer-spi/src/main/java/org/springframework/cloud/deployer/spi/AppDeployer.java
@@ -16,59 +16,61 @@
 
 package org.springframework.cloud.deployer.spi;
 
-import java.util.Map;
-
-import org.springframework.cloud.deployer.core.AppDeploymentId;
-import org.springframework.cloud.deployer.core.AppDeploymentRequest;
-import org.springframework.cloud.deployer.core.ArtifactMetadata;
-import org.springframework.cloud.deployer.status.AppStatus;
+import org.springframework.cloud.deployer.spi.status.AppStatus;
 
 /**
- * Interface specifying the operations for a runtime environment capable of
- * launching apps via {@link AppDeploymentRequest app deployment requests}.
+ * {@code AppDeployer} is a SPI defining a runtime environment capable of launching and
+ * handling apps. The term 'app' in a context of a {@code AppDeployer} is merely a runtime
+ * representation of a container or application wherein app should be executed.
+ *
+ * SPI itself doesn't expect deployer to keep state of a launched apps meaning it doesn't
+ * need to reconstruct all existing {@link AppStatus}s or {@link AppDeploymentId}s needed
+ * to resolve a {@link AppStatus}. Responsibility for keeping state of all existing apps
+ * lies to whomever is using this SPI. It is unrealistic to expect deployer to be able to
+ * store enough information using the underlying infrastructure order to reconstruct full
+ * history of a app executions.
  *
  * @author Mark Fisher
  * @author Patrick Peralta
  * @author Marius Bogoevici
+ * @author Janne Valkealahti
+ *
+ * @param <A> the type of artifact metadata
  */
 public interface AppDeployer<A extends ArtifactMetadata> {
 
 	/**
-	 * Handle the given {@code AppDeploymentRequest}. Implementations may
-	 * perform this operation asynchronously; therefore a successful deployment
-	 * may not be assumed upon return. To determine the status of a deployment,
+	 * Deploy an app using an {@link AppDeploymentRequest}. Returned
+	 * {@link AppDeploymentId} is later used with a {{@link #undeploy(AppDeploymentId)}
+	 * and a {{@link #status(AppDeploymentId)} to undeploy an app or get its status.
+	 *
+	 * Implementations may perform this operation asynchronously; therefore a successful
+	 * deployment may not be assumed upon return. To determine the status of a deployment,
 	 * invoke {@link #status(AppDeploymentId)}.
 	 *
-	 * @param request request for the app to be deployed
+	 * @param request the app deployment request
 	 * @return the deployment id for the app
 	 * @throws IllegalStateException if the app has already been deployed
 	 */
 	AppDeploymentId deploy(AppDeploymentRequest<A> request);
 
 	/**
-	 * Un-deploy the the given {@code AppDeploymenId}. Implementations may
+	 * Un-deploy an app using an {@link AppDeploymentRequest}. Implementations may
 	 * perform this operation asynchronously; therefore a successful
 	 * un-deployment may not be assumed upon return. To determine the status of
 	 * a deployment, invoke {@link #status(AppDeploymentId)}.
 	 *
-	 * @param id unique id for the app to be un-deployed
+	 * @param id the app deployment id
 	 * @throws IllegalStateException if the app has not been deployed
 	 */
 	void undeploy(AppDeploymentId id);
 
 	/**
+	 * Gets a {@link AppStatus} of an app represented by a {@link AppDeploymentId}.
 	 * Return the deployment status of the given {@code AppDeploymentId}.
 	 *
-	 * @param id id for the app this status is for
-	 * @return app deployment status
+	 * @param id the app deployment id
+	 * @return the app deployment status
 	 */
 	AppStatus status(AppDeploymentId id);
-
-	/**
-	 * Return a map of all deployed apps.
-	 *
-	 * @return map of deployed apps.
-	 */
-	Map<AppDeploymentId, AppStatus> status();
-
 }

--- a/spring-cloud-deployer-spi/src/main/java/org/springframework/cloud/deployer/spi/AppDeploymentId.java
+++ b/spring-cloud-deployer-spi/src/main/java/org/springframework/cloud/deployer/spi/AppDeploymentId.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,20 +14,29 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.deployer.core;
+package org.springframework.cloud.deployer.spi;
 
 import java.io.Serializable;
+import java.util.Collections;
+import java.util.Map;
 
 import org.springframework.util.Assert;
 
 /**
- * Unique identifier for an {@link AppDeploymentRequest}.
- * Methods {@link #toString()} and {@link #parse(String)} can be used to convert
- * an ID to a string and a string to an ID, respectively. The ID string may be
- * used to uniquely identify an app in a database or execution environment.
+ * {@code AppDeploymentId} is a representation constructed by a deployer based on a
+ * {@link AppDeploymentRequest}. {@code AppDeploymentId} contains everything what
+ * deployer needs to know order to either un-deploy or get a status of an app.
+ *
+ * Contract between {@link AppDeploymentRequest#getDeploymentProperties()} and
+ * {{@link AppDeploymentId#getProperties()} is up to the deployer implementation to decide
+ * and no other component should modify properties in this instance. For example, deployer
+ * may use deployment properties passed via {@link AppDeploymentRequest} as a hint to do
+ * something more clever and actual information needed for un-deploy or status would then
+ * be available from properties in this class.
  *
  * @author Patrick Peralta
  * @author Mark Fisher
+ * @author Janne Valkealahti
  */
 public class AppDeploymentId implements Serializable {
 
@@ -44,32 +53,64 @@ public class AppDeploymentId implements Serializable {
 	private final String name;
 
 	/**
-	 * Construct an {@code AppDeploymentId}.
+	 * The runtime deployment properties for app.
+	 */
+	private final Map<String, String> properties;
+
+	/**
+	 * Instantiates a new app deployment id.
 	 *
-	 * @param group name of group this app belongs to
-	 * @param name name to uniquely identify this app in its group
+	 * @param group the group
+	 * @param name the name
 	 */
 	public AppDeploymentId(String group, String name) {
+		this(group, name, null);
+	}
+
+	/**
+	 * Instantiates a new app deployment id.
+	 *
+	 * @param group the group
+	 * @param name the name
+	 * @param properties the properties
+	 */
+	public AppDeploymentId(String group, String name, Map<String, String> properties) {
 		Assert.hasText(group);
 		Assert.hasText(name);
 		Assert.doesNotContain(group, ".");
 		Assert.doesNotContain(name, ".");
 		this.group = group;
 		this.name = name;
+		this.properties = properties == null
+				? Collections.<String, String>emptyMap()
+				: Collections.unmodifiableMap(properties);
 	}
 
 	/**
-	 * @see #group
+	 * Gets the group name.
+	 *
+	 * @return the group name
 	 */
 	public String getGroup() {
 		return group;
 	}
 
 	/**
-	 * @see #name
+	 * Gets the app name.
+	 *
+	 * @return the app name
 	 */
 	public String getName() {
 		return name;
+	}
+
+	/**
+	 * Gets the deployment properties.
+	 *
+	 * @return the deployment properties
+	 */
+	public Map<String, String> getProperties() {
+		return properties;
 	}
 
 	@Override
@@ -107,35 +148,4 @@ public class AppDeploymentId implements Serializable {
 		}
 		return String.format("%s.%s", this.group, this.name);
 	}
-
-	/**
-	 * Parse the given string and return an {@code AppDeploymentId} based
-	 * on the string contents.
-	 *
-	 * @param id id containing the fields for an {@code AppDeploymentId}
-	 * @return a new {@code AppDeploymentId} based on the provided string
-	 * @throws IllegalArgumentException if a null or an invalid id is provided
-	 */
-	public static AppDeploymentId parse(String id) {
-		Assert.notNull(id, "id must not be null");
-		String[] fields = id.split("\\.");
-		if (fields.length == 1) {
-			return new AppDeploymentId(null, fields[0]);
-		}
-		if (fields.length == 2) {
-			return new AppDeploymentId(fields[0], fields[1]);
-		}
-		throw new IllegalArgumentException(String.format("invalid format for id '%s'", id));
-	}
-
-	/**
-	 * Return an {@code AppDeploymentId} based on the provided {@link AppDefinition}.
-	 *
-	 * @param definition app definition to generate an ID for
-	 * @return new {@code AppDeploymentId} for the provided app definition
-	 */
-	public static AppDeploymentId fromAppDefinition(AppDefinition definition) {
-		return new AppDeploymentId(definition.getGroup(), definition.getName());
-	}
-
 }

--- a/spring-cloud-deployer-spi/src/main/java/org/springframework/cloud/deployer/spi/AppDeploymentRequest.java
+++ b/spring-cloud-deployer-spi/src/main/java/org/springframework/cloud/deployer/spi/AppDeploymentRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.deployer.core;
+package org.springframework.cloud.deployer.spi;
 
 import java.util.Collections;
 import java.util.Map;
@@ -22,11 +22,23 @@ import java.util.Map;
 import org.springframework.util.Assert;
 
 /**
+ * {@code AppDeploymentRequest} contains a runtime representation of a task deployment.
+ *
+ * Deployment properties are always related to a SPI specific implementation and will never
+ * going to get passed into a task itself. For example, runtime container may allow to define
+ * various settings for a context where actual task is executed like allowed memory, cpu or
+ * simply various other way to define colocation like node labeling.
+ *
+ * For passing properties or parameters into an app, use {{@link AppDefinition#getParameters()}.
+ *
  * Representation of an app deployment request. This includes
  * app configuration properties as well as deployment properties.
  *
  * @author Patrick Peralta
  * @author Mark Fisher
+ * @author Janne Valkealahti
+ *
+ * @param <A> the type of artifact metadata
  */
 public class AppDeploymentRequest<A extends ArtifactMetadata> {
 
@@ -46,9 +58,9 @@ public class AppDeploymentRequest<A extends ArtifactMetadata> {
 	private final Map<String, String> deploymentProperties;
 
 	/**
-	 * Number of app instances to launch.
+	 * The deployment property count.
 	 */
-	private final int count;
+	public static String DEPLOYMENT_PROPERTY_COUNT = "org.springframework.cloud.deployer.spi.count";
 
 	/**
 	 * Construct an {@code AppDeploymentRequest}.
@@ -66,9 +78,6 @@ public class AppDeploymentRequest<A extends ArtifactMetadata> {
 		this.deploymentProperties = deploymentProperties == null
 				? Collections.<String, String>emptyMap()
 				: Collections.unmodifiableMap(deploymentProperties);
-		this.count = this.deploymentProperties.containsKey("count")
-				? Integer.parseInt(this.deploymentProperties.get("count"))
-				: 1;
 	}
 
 	/**
@@ -94,13 +103,6 @@ public class AppDeploymentRequest<A extends ArtifactMetadata> {
 	 */
 	public A getArtifactMetadata() {
 		return artifactMetadata;
-	}
-
-	/**
-	 * @see #count
-	 */
-	public int getCount() {
-		return count;
 	}
 
 	/**

--- a/spring-cloud-deployer-spi/src/main/java/org/springframework/cloud/deployer/spi/ArtifactMetadata.java
+++ b/spring-cloud-deployer-spi/src/main/java/org/springframework/cloud/deployer/spi/ArtifactMetadata.java
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.deployer.core;
+package org.springframework.cloud.deployer.spi;
 
 /**
+ * A marker interface for classes providing an {@code ArtifactMetadata}.
+ *
  * @author Mark Fisher
+ * @author Janne Valkealahti
  */
 public interface ArtifactMetadata {
-
 }

--- a/spring-cloud-deployer-spi/src/main/java/org/springframework/cloud/deployer/spi/status/AppInstanceStatus.java
+++ b/spring-cloud-deployer-spi/src/main/java/org/springframework/cloud/deployer/spi/status/AppInstanceStatus.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.deployer.status;
+package org.springframework.cloud.deployer.spi.status;
 
 import java.util.Map;
 

--- a/spring-cloud-deployer-spi/src/main/java/org/springframework/cloud/deployer/spi/status/AppStatus.java
+++ b/spring-cloud-deployer-spi/src/main/java/org/springframework/cloud/deployer/spi/status/AppStatus.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.deployer.status;
+package org.springframework.cloud.deployer.spi.status;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -22,12 +22,14 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.springframework.cloud.deployer.core.AppDeploymentId;
-import org.springframework.cloud.deployer.core.AppDeploymentRequest;
+import org.springframework.cloud.deployer.spi.AppDeploymentId;
+import org.springframework.cloud.deployer.spi.AppDeploymentRequest;
 
 /**
- * Status of an {@link AppDeploymentRequest}. This status is
- * composed of an aggregate of all individual app deployments.
+ * Status of an {@link AppDeploymentId} which is initially constructed
+ * from {@link AppDeploymentRequest} and runtime deployment properties by a deployer
+ * during a deployment. This status is composed of an aggregate of
+ * all individual app deployments.
  * <p>
  * Consumers of the SPI obtain app status via
  * {@link org.springframework.cloud.deployer.spi.AppDeployer#status},
@@ -130,11 +132,19 @@ public class AppStatus {
 		return new Builder(key);
 	}
 
-
+	/**
+	 * Utility class constructing an instance of a {@link AppStatus}
+	 * using a builder pattern.
+	 */
 	public static class Builder {
 
 		private final AppStatus status;
 
+		/**
+		 * Instantiates a new builder.
+		 *
+		 * @param key the app deployment id
+		 */
 		private Builder(AppDeploymentId key) {
 			this.status = new AppStatus(key);
 		}
@@ -142,7 +152,7 @@ public class AppStatus {
 		/**
 		 * Add an instance of {@code AppInstanceStatus} to build the status for
 		 * the app. This will be invoked once per individual app instance.
-		 * 
+		 *
 		 * @param instance status of individual app deployment
 		 * @return this {@code Builder}
 		 */
@@ -161,5 +171,4 @@ public class AppStatus {
 			return status;
 		}
 	}
-
 }

--- a/spring-cloud-deployer-spi/src/main/java/org/springframework/cloud/deployer/spi/status/DeploymentState.java
+++ b/spring-cloud-deployer-spi/src/main/java/org/springframework/cloud/deployer/spi/status/DeploymentState.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.deployer.status;
+package org.springframework.cloud.deployer.spi.status;
 
 /**
  * Deployment states for apps and groups. These may represent the


### PR DESCRIPTION
Overhaul proposal

I moved most of a stuff from core to spi as it feels a bit wrong for spi package not to keep all its dependant classes. Also changed core to depend on spi while it used to be other way around. Think spi package should be self sustained.

Removed AppDeployer.status() as it is impossible to implement and actually not even used in current ModuleDeployer.

`AppDeploymentId` is now a first class citizen and a central concept between deployer and spi user.
- `AppDeploymentId` now has a `Map<String, String> getProperties()` which deployer can populate order to make un-deploy and status requests more clever.
- Removed link and methods between `AppDefinition` and `AppDeploymentId` as id is created by deployer and definition cannot be used as is to create a fully qualified id to un-deploy or get status.

Polished javadocs to understand relationships better.

Removed count() from `AppDeploymentRequest` as its a bit awkard to keep on a class level.
- Tasks surely would not use it as is.
- `count` as a non-prefixed property would anyway cause trouble at some point as it's way too generic name.
- Think we can keep `count` around as a reserved property name.
- I'm sure we will add more generic properties in a future so I think it's simpler model this way.

Admin/Server would need to implement a new Repository interface keeping track of all deployed apps.
- We don't want to implement this behaviour within a deployer as it will just introduce more complexity and deployers are allready rather complex components.
- Also we want to have a single point where this is implemented as otherwise it'd be copy/pasting stuff into different deployers and that eventually leads to broken stuff.
- Tasks will have a bit more complex orchestration around app as there is a separate repos for keeping track of an actual job executions and it also need to query if the actual app running a job is deployed.

While I like an idea of using `ArtifactMetadata` as a marker interface allowing it to be transparent in an `ArtifactResolver` interface, I see some trouble of its use in an `AppDeployer` generic type `A`. Shared controller classes in a server core are the ones using `AppDeployer` api's and looks like type `A` as `MavenCoordinates` would always be hardcoded. If we want to have a different metadata type other than `MavenCoordinates`, how would server core use those? Looks like we'd need to create beans as `mavenStreamAppDeployer` and `mavenTaskAppDeployer` if we some day want to have `ivyStreamAppDeployer` and `ivyTaskAppDeployer`. Hope you get the point I'm chasing here as I don't fully understand the metadata's use concept from server core point of view.
